### PR TITLE
Fix: Unexisting Vee Validate rule referenced in reset password field

### DIFF
--- a/client/common/validation.js
+++ b/client/common/validation.js
@@ -1,4 +1,13 @@
-import { alpha, email, is, max, mimes, min, required } from 'vee-validate/dist/rules';
+import {
+  alpha,
+  confirmed,
+  email,
+  is,
+  max,
+  mimes,
+  min,
+  required
+} from 'vee-validate/dist/rules';
 import { extend } from 'vee-validate';
 import forEach from 'lodash/forEach';
 import isURL from 'validator/lib/isURL';
@@ -39,6 +48,7 @@ const uniqueEmail = {
 const rules = {
   alpha,
   alphanumerical,
+  confirmed,
   email,
   is,
   max,

--- a/client/main/components/auth/ResetPassword.vue
+++ b/client/main/components/auth/ResetPassword.vue
@@ -26,9 +26,9 @@
       </validation-provider>
       <validation-provider
         v-slot="{ errors }"
+        :validate="{ rules: { required: true, is: password } }"
         vid="passwordConfirmation"
-        name="password"
-        rules="required|confirmed:password">
+        name="password">
         <v-text-field
           v-model="passwordConfirmation"
           :error-messages="errors"

--- a/client/main/components/auth/ResetPassword.vue
+++ b/client/main/components/auth/ResetPassword.vue
@@ -26,7 +26,7 @@
       </validation-provider>
       <validation-provider
         v-slot="{ errors }"
-        :validate="{ rules: { required: true, is: password } }"
+        :rules="{ required: true, confirmed: { target: 'password' } }"
         vid="passwordConfirmation"
         name="password">
         <v-text-field


### PR DESCRIPTION
#### Bug
_Confirm password_ field referenced unexisting VV rule "confirmation".
#### Solution
Replaced rule with validate object that defines `required` and `is` (comparison with `password` value) rules.